### PR TITLE
Made possible to serve query strings on API side.

### DIFF
--- a/docker/elo_www/site.conf
+++ b/docker/elo_www/site.conf
@@ -10,7 +10,7 @@ server {
     }
 
     location ~ ^/api/(.*)$ {
-        proxy_pass http://172.16.11.2:80/Api/$1;
+        proxy_pass http://172.16.11.2:80/Api/$1$is_args$args;
         proxy_redirect off;
         proxy_set_header X-Real-IP  $remote_addr;
         proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Po stronie API nie można było obsługiwać parametrów `$_GET`. Ten PR to naprawia. Prosta poprawka, ale wiele musiało się próbować i Googlować...